### PR TITLE
fix: webln.enable has no return value

### DIFF
--- a/app/inst/webln.R
+++ b/app/inst/webln.R
@@ -25,8 +25,8 @@ requestLoginEnable <- function(id) {
 	glue::glue(.open = "{{{", .close = "}}}", '
 	shinyjs.webln_login_enable = async function() {
 	  try {
-		const status = await window.webln.enable();
-		Shiny.setInputValue("{{{id}}}", status.enabled);
+		await window.webln.enable();
+		Shiny.setInputValue("{{{id}}}", true);
 	  }
 	  catch(error) {
 		Shiny.setInputValue("{{{id}}}", {catch: error.name, reason: error.message});
@@ -37,8 +37,8 @@ requestEarnEnable <- function(id) {
 	glue::glue(.open = "{{{", .close = "}}}", '
 	shinyjs.webln_earn_enable = async function() {
 	  try {
-		const status = await window.webln.enable();
-		Shiny.setInputValue("{{{id}}}", status.enabled);
+		await window.webln.enable();
+		Shiny.setInputValue("{{{id}}}", true);
 	  }
 	  catch(error) {
 		Shiny.setInputValue("{{{id}}}", {catch: error.name, reason: error.message});


### PR DESCRIPTION
According to the WebLN spec the `enable()` call is `void` and has been wrongly implemented by Alby which has been fixed with this PR: 

https://github.com/getAlby/lightning-browser-extension/pull/2599

This change makes LNNode Insight compatible with the spec.